### PR TITLE
Substitute "-a" with "-e" in file existence tests in the top-level Makefile…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,22 @@ hrv-ediggenesys2: tc-hrv-olinux tc-pulp br-hrv-ediggenesys2 sdk-pulp sdk-hrv tc-
 .PHONY: prem-set prem-unset
 prem-set:
 	# Remove if already exists
-	if [ -a $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_CMUX_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
-	if [ -a $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_OMP_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
+	if [ -e $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_CMUX_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
+	if [ -e $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_OMP_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
 	# Re-add
 	echo "$(PREM_BR_CMUX_CONFSTR)" >> $(CURDIR)/local.cfg
 	echo "$(PREM_BR_OMP_CONFSTR)" >> $(CURDIR)/local.cfg
 
 prem-unset:
 	# Remove local buildroot config lines if they exist
-	if [ -a $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_CMUX_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
-	if [ -a $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_OMP_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
+	if [ -e $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_CMUX_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
+	if [ -e $(CURDIR)/local.cfg ]; then grep -v "$(PREM_BR_OMP_CONFSTR)" local.cfg > local.tmp.cfg; mv local.tmp.cfg local.cfg; fi
 
 # environment
 br-hrv-ediggenesys2-base: check_environment
 	mkdir -p $(CURDIR)/output/br-hrv-ediggenesys2
 	$(MAKE) O=$(CURDIR)/output/br-hrv-ediggenesys2 BR2_EXTERNAL=$(ROOT) -C $(ROOT)/buildroot hrv_ediggenesys2_defconfig
-	if [ -a $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv-ediggenesys2/.config; fi
+	if [ -e $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv-ediggenesys2/.config; fi
 	$(MAKE) -C $(CURDIR)/output/br-hrv-ediggenesys2
 	cp $(CURDIR)/output/br-hrv-ediggenesys2/images/bbl.bin $(CURDIR)/output/hrv-ediggenesys-base-bbl.bin
 br-hrv-ediggenesys2: br-hrv-ediggenesys2-base
@@ -38,7 +38,7 @@ br-hrv-ediggenesys2: br-hrv-ediggenesys2-base
 br-har-exilzcu102-base: check_environment
 	mkdir -p $(CURDIR)/output/br-har-exilzcu102
 	$(MAKE) O=$(CURDIR)/output/br-har-exilzcu102 BR2_EXTERNAL=$(ROOT) -C $(ROOT)/buildroot har_exilzcu102_defconfig
-	if [ -a $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-har-exilzcu102/.config; fi
+	if [ -e $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-har-exilzcu102/.config; fi
 	$(MAKE) -C $(CURDIR)/output/br-har-exilzcu102
 	cp $(CURDIR)/output/br-har-exilzcu102/images/sdcard.img $(CURDIR)/output/har-exilzcu102-base-sdcard.img
 br-har-exilzcu102: br-har-exilzcu102-base
@@ -47,7 +47,7 @@ br-har-exilzcu102: br-har-exilzcu102-base
 br-hrv: check_environment
 	mkdir -p $(CURDIR)/output/br-hrv
 	$(MAKE) O=$(CURDIR)/output/br-hrv BR2_EXTERNAL=$(ROOT) -C $(ROOT)/buildroot hrv_defconfig
-	if [ -a $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv/.config; fi
+	if [ -e $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv/.config; fi
 	$(MAKE) -C $(CURDIR)/output/br-hrv
 	cp $(CURDIR)/output/br-hrv/images/rootfs.ext4 $(CURDIR)/output/hrv-rootfs.ext4
 	cp $(CURDIR)/output/br-hrv/images/rootfs.tar $(CURDIR)/output/hrv-rootfs.tar
@@ -55,7 +55,7 @@ br-hrv: check_environment
 br-har: check_environment
 	mkdir -p $(CURDIR)/output/br-har
 	$(MAKE) O=$(CURDIR)/output/br-har BR2_EXTERNAL=$(ROOT) -C $(ROOT)/buildroot har_defconfig
-	if [ -a $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-har/.config; fi
+	if [ -e $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-har/.config; fi
 	$(MAKE) -C $(CURDIR)/output/br-har
 	cp $(CURDIR)/output/br-har/images/rootfs.ext4 $(CURDIR)/output/har-rootfs.ext4
 	cp $(CURDIR)/output/br-har/images/rootfs.tar $(CURDIR)/output/har-rootfs.tar
@@ -64,7 +64,7 @@ br-har: check_environment
 br-hrv-eqemu-base: check_environment
 	mkdir -p $(CURDIR)/output/br-hrv-eqemu
 	$(MAKE) O=$(CURDIR)/output/br-hrv-eqemu BR2_EXTERNAL=$(ROOT) -C $(ROOT)/buildroot hrv_eqemu_defconfig
-	if [ -a $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv-eqemu/.config; fi
+	if [ -e $(CURDIR)/local.cfg ]; then cat $(CURDIR)/local.cfg >> $(CURDIR)/output/br-hrv-eqemu/.config; fi
 	$(MAKE) -C $(CURDIR)/output/br-hrv-eqemu
 	cp $(CURDIR)/output/br-hrv-eqemu/images/fw_jump.bin $(CURDIR)/output/hrv-eqemu-base-fw_jump.bin
 	cp $(CURDIR)/output/br-hrv-eqemu/images/rootfs.ext2 $(CURDIR)/output/hrv-eqemu-base-rootfs.ext2


### PR DESCRIPTION
…

Unary "-a" is bash-specific and can be confused with binary "-a" in a number of subtle ways. "-e" does the same, is not ambiguous and works in any sh-like shell and in both POSIX and GNU test(1) commands.